### PR TITLE
Fix serious GCC and flash memory issue

### DIFF
--- a/.cproject
+++ b/.cproject
@@ -65,7 +65,7 @@
 									<listOptionValue builtIn="false" value="m"/>
 								</option>
 								<option id="gnu.c.link.option.paths.1398755266" name="Library search path (-L)" superClass="gnu.c.link.option.paths"/>
-								<option id="gnu.c.link.option.ldflags.740755895" name="Linker flags" superClass="gnu.c.link.option.ldflags" value="-specs=nosys.specs -specs=nano.specs" valueType="string"/>
+								<option id="gnu.c.link.option.ldflags.740755895" name="Linker flags" superClass="gnu.c.link.option.ldflags" value="-specs=nosys.specs -specs=nano.specs  -u _printf_float -u _scanf_float" valueType="string"/>
 								<inputType id="cdt.managedbuild.tool.gnu.c.linker.input.366443294" superClass="cdt.managedbuild.tool.gnu.c.linker.input">
 									<additionalInput kind="additionalinputdependency" paths="$(USER_OBJS)"/>
 									<additionalInput kind="additionalinput" paths="$(LIBS)"/>

--- a/STM32F407VGTx_FLASH.ld
+++ b/STM32F407VGTx_FLASH.ld
@@ -67,7 +67,7 @@ CCMRAM (rw)      : ORIGIN = 0x10000000, LENGTH = 64K
 
 /* Define output sections */
 SECTIONS
-{
+{  
   /* The startup code goes first into FLASH */
   .isr_vector :
   {
@@ -75,6 +75,15 @@ SECTIONS
     KEEP(*(.isr_vector)) /* Startup code */
     . = ALIGN(4);
   } >FLASH
+  
+    /* Placing of the COMMS flash storage */
+  .comms_storage_section 0x0800C000 :
+  {
+    . = ALIGN(4);
+    KEEP(*(.comms_storage_section)) /* keep variable even if not referenced */
+    . = ALIGN(4);
+  } >FLASH
+  
 
   /* The program code and other data goes into FLASH */
   .text :

--- a/Src/comms_manager.c
+++ b/Src/comms_manager.c
@@ -31,6 +31,7 @@
 #include "comms.h"
 #include "verification_service.h"
 #include "large_data_service.h"
+#include "sensors.h"
 
 #undef __FILE_ID__
 #define __FILE_ID__ 25
@@ -298,4 +299,7 @@ comms_init ()
   cw_init();
 
   large_data_init();
+
+  /* Initialize temperature sensor */
+  init_adt7420 ();
 }

--- a/Src/main.c
+++ b/Src/main.c
@@ -182,8 +182,6 @@ int main(void)
 
   HAL_Delay (100);
 
-  init_adt7420 ();
-
   pkt_pool_INIT ();
 
   uint16_t size = 0;
@@ -196,7 +194,7 @@ int main(void)
 
   /* Sent to OBC the reason of re-booting */
   HAL_reset_source(&rst_src);
-  event_boot(rst_src);
+  event_boot(rst_src, 0);
 
   /* USER CODE END 2 */
 
@@ -207,6 +205,7 @@ int main(void)
   while (1) {
     HAL_IWDG_Refresh(&hiwdg);
     import_pkt (OBC_APP_ID, &comms_data.obc_uart);
+    export_pkt (OBC_APP_ID, &comms_data.obc_uart);
 
     /* Check if a CW beacon should be sent */
     if(HAL_GetTick() - cw_tick > __CW_INTERVAL_MS ) {
@@ -265,10 +264,9 @@ int main(void)
     large_data_IDLE();
 #endif
 
-    /*------------TEMP------------*/
+    /* Update the temperature readings */
+    update_adt7420();
 
-    //large_data_IDLE();
-    //HAL_Delay (100);
   /* USER CODE END WHILE */
 
   /* USER CODE BEGIN 3 */

--- a/Src/sensors.c
+++ b/Src/sensors.c
@@ -66,7 +66,9 @@ update_adt7420 ()
             i2c_temp, 1, ADT7420_TIMEOUT);
   lsb = i2c_temp[0];
 
-  if(resM != HAL_OK || resL != HAL_OK ) { return 0; }
+  if (resM != HAL_OK || resL != HAL_OK) {
+    return 0.0;
+  }
 
   temp_sensor.temp_raw = msb << 8;
   temp_sensor.temp_raw |= lsb;


### PR DESCRIPTION
GCC does not support the #pragma location macro. So the flash memory
storage block could actually write/erase on the .text or .data segment
of the program
